### PR TITLE
fix(vue_use): Fix typo in 'reduce_vue_use'

### DIFF
--- a/trame_server/utils/__init__.py
+++ b/trame_server/utils/__init__.py
@@ -57,7 +57,7 @@ def reduce_vue_use(state):
 
         _options.setdefault(name, {})
         if name not in _order:
-            _order.append(item)
+            _order.append(name)
 
         update_dict(_options[name], options)
 


### PR DESCRIPTION
Could not pass options before like this: vue_use = [('trame_component', {...})]