### PR TITLE
feat(security): Use authKeyFile argument if present

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords =
 packages = find:
 include_package_data = True
 install_requires =
-    wslink>=1.9.0
+    wslink>=1.9.2
 
 [semantic_release]
 version_pattern = setup.cfg:version = (\d+\.\d+\.\d+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords =
 packages = find:
 include_package_data = True
 install_requires =
-    wslink>=1.9.2
+    wslink>=1.9.0
 
 [semantic_release]
 version_pattern = setup.cfg:version = (\d+\.\d+\.\d+)

--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -279,7 +279,7 @@ class Server:
         self._cli_parser.add_argument(
             "--authKeyFile",
             help="""Path to a File that contains the Authentication key for clients
-                    to connect to the WebSocket. 
+                    to connect to the WebSocket.
                     This takes precedence over '-a, --authKey' from wslink.""",
         )
 

--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -278,7 +278,9 @@ class Server:
         )
         self._cli_parser.add_argument(
             "--authKeyFile",
-            help="Path to a File that contains the Authentication key for clients to connect to the WebSocket. This takes precedence over '-a, --authKey' from wslink."
+            help="""Path to a File that contains the Authentication key for clients
+                    to connect to the WebSocket. 
+                    This takes precedence over '-a, --authKey' from wslink.""",
         )
 
         CoreServer.add_arguments(self._cli_parser)

--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -276,6 +276,10 @@ class Server:
             dest="no_http",
             action="store_true",
         )
+        self._cli_parser.add_argument(
+            "--authKeyFile",
+            help="Path to a File that contains the Authentication key for clients to connect to the WebSocket. This takes precedence over '-a, --authKey' from wslink."
+        )
 
         CoreServer.add_arguments(self._cli_parser)
 

--- a/trame_server/protocol.py
+++ b/trame_server/protocol.py
@@ -32,7 +32,11 @@ class CoreServer(ServerProtocol):
 
     @staticmethod
     def configure(args):
-        CoreServer.authentication_token = args.authKey
+        if args.authKeyFile:
+            with open(args.authKeyFile) as key_file:
+                CoreServer.authentication_token = key_file.read().strip()
+        else:
+            CoreServer.authentication_token = args.authKey
 
     @staticmethod
     def server_start(options, **kwargs):


### PR DESCRIPTION
As mentioned in kitware/wslink#124, for security reasons there should be an option to pass the authKey as the path to a file instead via a command line argument.

With this approach, `authKeyFile` will take precedence over `authKey`. I think this should ideally be the other way around, but since `authKey` has a default argument, a check whether the user explicitly specified the `authKey` option is not directly possible. If desired, we could prevent that problem by [making the 2 arguments mutually exclusive](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group).