### PR TITLE
Add ability to specify trame arguments in different ways

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,9 @@
 [flake8]
 
-# Match the max line length we have set for black
-max-line-length = 88
+# Just assume black did a good job with the line lengths
+ignore =
+    E501
 
 # Black sometimes conflicts with flake8 here
-extend-ignore = E203
+# Ignore white space before colon and after binary operator
+extend-ignore = E203, W503

--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import inspect
 import logging
@@ -11,6 +10,7 @@ from .state import State
 from .controller import Controller
 from .ui import VirtualNodeManager
 from .protocol import CoreServer
+from .utils.argument_parser import ArgumentParser
 
 
 class Server:
@@ -294,7 +294,7 @@ class Server:
         if self._cli_parser:
             return self._cli_parser
 
-        self._cli_parser = argparse.ArgumentParser(description="Kitware trame")
+        self._cli_parser = ArgumentParser(description="Kitware trame")
 
         # Trame specific args
         self._cli_parser.add_argument(

--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -326,6 +326,13 @@ class Server:
                     located in the site-packages directories are skipped.""",
             action="store_true",
         )
+        self._cli_parser.add_argument(
+            "--trame-args",
+            help="""If specified, trame will ignore all other arguments, and only the contents
+                    of the `--trame-args` will be used. For example:
+                    `--trame-args="-p 8081 --server"`. Alternatively, the environment variable
+                    `TRAME_ARGS` may be set instead.""",
+        )
 
         CoreServer.add_arguments(self._cli_parser)
 

--- a/trame_server/utils/argument_parser.py
+++ b/trame_server/utils/argument_parser.py
@@ -1,0 +1,40 @@
+import argparse
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """Custom argument parser for Trame
+
+    We will skip argument parsing under certain conditions, such as if
+    pytest is running or the "TRAME_ARGS_DISABLED" environment variable
+    is set.
+    """
+
+    def parse_known_args(self, args=None, namespace=None):
+        if args is None and self._default_parsing_disabled:
+            # If default parsing is disabled, don't allow it to parse sys.argv.
+            # Pass it an empty list instead.
+            logger.debug("Skipping default argument parsing...")
+            args = []
+
+        return super().parse_known_args(args, namespace)
+
+    @property
+    def _default_parsing_disabled(self):
+        args_disabled_env = "TRAME_ARGS_DISABLED"
+        if args_disabled_env in os.environ:
+            falsy_values = (None, "", "0", "false")
+            return os.environ[args_disabled_env] not in falsy_values
+
+        # If TRAME_ARGS_DISABLED was not set and we are in pytest, then
+        # also disable parsing.
+        # Assume we are in pytest if pytest was imported
+        # See discussion: https://github.com/pytest-dev/pytest/issues/9502
+        if "pytest" in sys.modules:
+            return True
+
+        return False

--- a/trame_server/utils/argument_parser.py
+++ b/trame_server/utils/argument_parser.py
@@ -1,40 +1,68 @@
 import argparse
-import logging
 import os
 import sys
-
-logger = logging.getLogger(__name__)
 
 
 class ArgumentParser(argparse.ArgumentParser):
     """Custom argument parser for Trame
 
-    We will skip argument parsing under certain conditions, such as if
-    pytest is running or the "TRAME_ARGS_DISABLED" environment variable
-    is set.
+    In this class, `parse_known_args()` has a custom implementation.
+
+    Normally, this would parse sys.argv[1:] as normal, but it will be different
+    under the following conditions:
+
+    1. A `--trame-args` argument is provided. If this is provided, then
+       only the arguments supplied to this argument will be used for trame.
+       For instance: `--trame-args="-p 8081 --server"` will mean the args
+       parsed for trame will be `-p 8081 --server`.
+    2. A `TRAME_ARGS` environment variable is set. If this is set, then
+       only the arguments supplied to this environment variable will be used
+       for trame.
+       For instance: `TRAME_ARGS="-p 8081 --server"` will mean the args
+       parsed for trame will be `-p 8081 --server`.
+    3. The `pytest` module has been loaded. If this is the case, then we
+       will automatically ignore `sys.argv` because `pytest` will not
+       allow for arguments it does not recognize. If `pytest` has been
+       loaded, the only way to specify trame arguments is through the
+       `TRAME_ARGS` environment variable mentioned in #2.
     """
 
     def parse_known_args(self, args=None, namespace=None):
-        if args is None and self._default_parsing_disabled:
-            # If default parsing is disabled, don't allow it to parse sys.argv.
-            # Pass it an empty list instead.
-            logger.debug("Skipping default argument parsing...")
-            args = []
-
+        # The trame arguments are usually specified as normal, but they
+        # can be alternatively specified via an environment variable or
+        # via `--trame-args="..."`.
+        args = self._extract_trame_args(args)
         return super().parse_known_args(args, namespace)
 
+    def _extract_trame_args(self, args):
+        """Extract the arguments we will parse in trame"""
+        if args is not None:
+            # If the args is not None, then we are analyzing specific arguments.
+            # Just return it the way it is.
+            return args
+
+        args = [] if self._skip_default_parsing else sys.argv[1:]
+        if any(x.startswith("--trame-args") for x in sys.argv[1:]):
+            # Allow argparse to handle all of the different ways this argument may be specified
+            tmp_parser = argparse.ArgumentParser()
+            tmp_parser.add_argument("--trame-args")
+            out, _ = tmp_parser.parse_known_args(sys.argv[1:])
+            # Add these in
+            args += out.trame_args.split()
+        elif "TRAME_ARGS" in os.environ:
+            # If "--trame-args" wasn't specified, check the environment variable.
+            args += os.environ["TRAME_ARGS"].split()
+
+        return args
+
     @property
-    def _default_parsing_disabled(self):
-        args_disabled_env = "TRAME_ARGS_DISABLED"
-        if args_disabled_env in os.environ:
-            falsy_values = (None, "", "0", "false")
-            return os.environ[args_disabled_env] not in falsy_values
-
-        # If TRAME_ARGS_DISABLED was not set and we are in pytest, then
-        # also disable parsing.
-        # Assume we are in pytest if pytest was imported
-        # See discussion: https://github.com/pytest-dev/pytest/issues/9502
-        if "pytest" in sys.modules:
-            return True
-
-        return False
+    def _skip_default_parsing(self):
+        # Skip the default parsing if the trame arguments were set another
+        # way, such as the environment variable or the `--trame-args="..."` arg.
+        # Also, skip the default parsing if we are in pytest, because pytest
+        # will definitely not allow us to have extra arguments anyways.
+        return (
+            "TRAME_ARGS" in os.environ
+            or any(x.startswith("--trame-args") for x in sys.argv[1:])
+            or "pytest" in sys.modules
+        )


### PR DESCRIPTION
This adds the ability to specify trame arguments in a couple of different ways:

1. Via a `--trame-args` argument. For instance, if you specify `--trame-args="-p 8081 --server"`, all other arguments will be ignored by trame and only the contents of the `trame-args` will be used by trame.
2. Via a `TRAME_ARGS` environment variable. This can be helpful if trame is being used in another library that doesn't allow for arguments that it is unaware of (such as `pytest`).

Also as a part of this PR: if `pytest` is in `sys.modules`, trame will not parse the arguments in `sys.argv`. This is because `pytest` will not allow for custom arguments anyways, and trame parsing the `pytest` arguments was causing an error before.

Implementation details: this adds an `ArgumentParser` class (that inherits from `argparse.ArgumentParser`) which we now use on the trame server. In this class, the `parse_known_args()` function is overridden so that we can customize the arguments that are read in by trame.

Fixes: pyvista/pyvista#3973