### PR TITLE
Improve print_informations

### DIFF
--- a/trame_server/core.py
+++ b/trame_server/core.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 import os
 import sys
+from typing import Optional
 
 from . import utils
 
@@ -437,7 +438,7 @@ class Server:
         self,
         port: int = None,
         thread: bool = False,
-        open_browser: bool = True,
+        open_browser: Optional[bool] = None,
         show_connection_info: bool = True,
         disable_logging: bool = False,
         backend: str = None,
@@ -487,6 +488,9 @@ class Server:
             from trame_client import module
 
             self.enable_module(module)
+
+        if open_browser is None:
+            open_browser = not os.environ.get("TRAME_SERVER", False)
 
         # Trigger on_server_start life cycle callback
         if self.controller.on_server_start.exists():
@@ -563,6 +567,7 @@ class Server:
             options.content = ""
             options.fsEndpoints = ""
 
+        self._server_options = options
         CoreServer.configure(options)
 
         self._running_stage = 1
@@ -617,3 +622,8 @@ class Server:
     def port(self):
         """Once started, you can retrieve the port used"""
         return self._running_port
+
+    @property
+    def server_options(self):
+        """Once started, you can retrieve the server options used"""
+        return self._server_options

--- a/trame_server/utils/server.py
+++ b/trame_server/utils/server.py
@@ -3,18 +3,21 @@ import socket
 
 
 def print_informations(server):
-    args = server.cli.parse_known_args()[0]
-    local_url = f"http://{args.host}:{args.port}/"
+    options = server.server_options
+    local_url = f"http://{options.host}:{server.port}/"
     print()
     print("App running at:")
     print(f" - Local:   {local_url}")
 
     try:
-        host_name = socket.gethostname()
-        host_ip = socket.gethostbyname(host_name)
+        try:
+            host_ip = socket.gethostbyname(options.host)
+        except Exception:
+            host_name = socket.gethostname()
+            host_ip = socket.gethostbyname(host_name)
         print(f" - Network: http://{host_ip}:{server.port}/")
     except socket.gaierror:
-        print(f" - Network: http://{args.host}:{server.port}/")
+        print(f" - Network: http://{options.host}:{server.port}/")
         pass
 
     print()


### PR DESCRIPTION
I noticed that if I set `TRAME_DEFAULT_HOST`, this would not properly display in the console message. This fixes that. Further, the network IP was pretty much always using localhost/127.0.0.1 and not properly mapping to the host IP so I fixed that too.

I also wanted a way to tell trame to not attempt opening the web browser by setting `TRAME_SERVER=true` in the environment