### PR TITLE
fix(controller): trigger name namespacing

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,10 @@
-import pytest
 import logging
 
+import pytest
+
+from trame_server import Server
 from trame_server.controller import FunctionNotImplementedError
+from trame_server.utils.namespace import Translator
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +34,18 @@ def test_trigger_name(controller):
     assert a_name == a_name_next
     assert a_name == "trigger__1"
     assert b_name == "trigger__2"
+
+
+def test_trigger_translator():
+    prefix = "ctrl_test_prefix_"
+    server = Server(translator=Translator(prefix))
+
+    def func():
+        return None
+
+    trigger_name = server.controller.trigger_name(func)
+
+    assert trigger_name == f"{prefix}trigger__1"
+    assert server.controller.trigger_fn(trigger_name) == func
+
+    server.controller.trigger_name(func) == trigger_name

--- a/trame_server/controller.py
+++ b/trame_server/controller.py
@@ -69,7 +69,7 @@ class Controller:
             logger.info("trigger(%s)", name)
             self._triggers[name] = func
             self._triggers_fn2name[func] = name
-            return func
+            return func, name
 
         return register_trigger
 
@@ -85,8 +85,8 @@ class Controller:
             return self._triggers_fn2name[fn]
 
         name = f"trigger__{self._triggers_name_id.next()}"
-        self.trigger(name)(fn)
-        return name
+        _, translated_name = self.trigger(name)(fn)
+        return translated_name
 
     def trigger_fn(self, name):
         """


### PR DESCRIPTION
using  `trigger_name` function would not return the correct namespaced name in case of a server with a translator.  
You can reproduce the problem by passing a function directly to a component event that holds a namespaced trame server.
@jourdain is the change is acceptable regarding breaking change for other packages?