### PR TITLE
feat(state): add change listener suppression context manager

### DIFF
--- a/src/trame_server/state.py
+++ b/src/trame_server/state.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import weakref
+from collections import deque
 from contextlib import contextmanager
 
 from .utils import asynchronous, is_dunder, is_private, share
@@ -63,6 +64,66 @@ class StateChangeHandler:
         return iter(list(self._currents))
 
 
+class _SuppressListenersChangeStack:
+    """
+    Helper class to handle change listener keys to suppress and which to trigger.
+    """
+
+    def __init__(self):
+        self._deque: deque[set[str]] = deque()
+        self._suppressed_keys: set[str] | None = None
+        self._listener_keys: set[str] = set()
+
+    def on_pending_key_added(self, key: str) -> None:
+        if not self._is_suppressed(key):
+            self._listener_keys.add(key)
+
+    def on_pending_key_removed(self, key: str) -> None:
+        self._listener_keys.discard(key)
+
+    def push(self, *keys: str) -> None:
+        self._deque.append(set(keys))
+        self._update_suppressed_keys()
+
+    def pop(self) -> None:
+        if not self._deque:
+            return
+
+        self._deque.pop()
+        self._update_suppressed_keys()
+
+    def clear(self) -> None:
+        self._listener_keys = set()
+
+    def get_change_listener_keys(self) -> set[str]:
+        return self._listener_keys
+
+    def _is_suppressed(self, key: str) -> bool:
+        if self._suppressed_keys is None:
+            return False
+        if self._suppressed_keys == set():
+            return True
+        return key in self._suppressed_keys
+
+    def _update_suppressed_keys(self) -> None:
+        """
+        Updates the suppressed keys set.
+        If the stack is empty, the suppressed keys will be reset to None.
+        If the stack contains one empty set (catch all) the suppressed set will be updated to an empty set (catch all).
+        Otherwise, the suppressed keys will represent the union of the stack's sets.
+        """
+        if not self._deque:
+            self._suppressed_keys = None
+            return
+
+        self._suppressed_keys = set()
+        for d_set in self._deque:
+            if d_set == set():
+                self._suppressed_keys.clear()
+                return
+            self._suppressed_keys.update(d_set)
+
+
 class State:
     """
     Flexible dictionary managing a server shared state.
@@ -100,6 +161,8 @@ class State:
         if internal:
             internal._children_state.append(self)
 
+        self._suppress_change_stack = _SuppressListenersChangeStack()
+
     @property
     def is_ready(self) -> bool:
         """Return True is the instance is ready for synchronization, False otherwise."""
@@ -127,9 +190,11 @@ class State:
         if key in self._pushed_state:
             if value == self._pushed_state[key]:
                 self._pending_update.pop(key, None)
+                self._suppress_change_stack.on_pending_key_removed(key)
                 return
 
         self._pending_update[key] = value
+        self._suppress_change_stack.on_pending_key_added(key)
 
     def __getattr__(self, key):
         if is_dunder(key):
@@ -240,6 +305,7 @@ class State:
         This will prevent change listener(s) to react or the client
         to be aware of any change.
         """
+        self._suppress_change_stack.clear()
         _args = self._translator.translate_list(_args)
         for key in _args:
             if key in self._pending_update:
@@ -252,6 +318,9 @@ class State:
         for key in _dict:
             if _dict[key] == self._pushed_state.get(key, TRAME_NON_INIT_VALUE):
                 self._pending_update.pop(key, None)
+                self._suppress_change_stack.on_pending_key_removed(key)
+            else:
+                self._suppress_change_stack.on_pending_key_added(key)
 
     @property
     def modified_keys(self):
@@ -300,7 +369,13 @@ class State:
         self._pending_update.clear()
 
         # Execute state listeners
-        self._state_listeners.add_all(_keys)
+        self._state_listeners.add_all(
+            self._suppress_change_stack.get_change_listener_keys()
+        )
+
+        # Clear change keys before triggering listeners as listeners can trigger modifications in chain
+        self._suppress_change_stack.clear()
+
         for fn, translator in self._state_listeners:
             if isinstance(fn, weakref.WeakMethod):
                 callback = fn()
@@ -387,3 +462,21 @@ class State:
             return func
 
         return register_change_callback
+
+    @contextmanager
+    def suppress_change_listeners(self, *keys: str):
+        """
+        Suppresses input keys from triggering a state.change callback event in the scope of the context manager.
+        Suppression only impacts the server and any state changed will be properly sent to the client.
+
+        If called without arguments, suppress_change_listeners will suppress all listener changes in its scope.
+        When used in a child state, the input key should be the untranslated state key.
+        """
+
+        self._suppress_change_stack.push(
+            *[self.translator.translate_key(k) for k in keys]
+        )
+        try:
+            yield
+        finally:
+            self._suppress_change_stack.pop()

--- a/src/trame_server/utils/typed_state.py
+++ b/src/trame_server/utils/typed_state.py
@@ -1,5 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import MISSING, Field, fields, is_dataclass
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
@@ -650,3 +651,15 @@ class TypedState(Generic[T]):
             data=sub_data,
             name=sub_name,
         )
+
+    @contextmanager
+    def suppress_change_listeners(self):
+        """
+        Suppresses bind_changes callbacks bound to any typed state name from triggering in the current context.
+        Suppression only impacts the server and any state changed will be properly sent to the client.
+        """
+
+        with self.state.suppress_change_listeners(
+            *list(self.get_field_proxy_dict(self.name).keys())
+        ):
+            yield

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,26 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
+import pytest_asyncio
 from trame.app import asynchronous, get_client, get_server
 
 
-@pytest.mark.asyncio
-async def test_client_connection():
+@pytest_asyncio.fixture
+async def server():
     server = get_server("test_client_connection")
     server.start(exec_mode="task", port=0)
     assert await server.ready
     assert server.running
+    try:
+        yield server
+    finally:
+        await asyncio.sleep(0.5)
+        await server.stop()
 
+
+@pytest_asyncio.fixture
+async def client(server):
     url = f"ws://localhost:{server.port}/ws"
     client = get_client(url)
     asynchronous.create_task(client.connect(secret="wslink-secret"))
@@ -22,9 +32,17 @@ async def test_client_connection():
 
     # should be a noop
     await client.connect()
-
     assert client.connected == 2
 
+    try:
+        yield client
+    finally:
+        await asyncio.sleep(0.1)
+        await client.diconnect()
+
+
+@pytest.mark.asyncio
+async def test_client_connection(server, client):
     @client.change("a")
     def on_change(a, **_):
         assert a == 2
@@ -53,7 +71,20 @@ async def test_client_connection():
     assert await client.call_trigger("add", [1, 2, 3]) == 6
     assert await client.call_trigger("add") == 0
 
+
+@pytest.mark.asyncio
+async def test_given_suppress_listeners_sends_updates_to_client_only(server, client):
+    state_key = "my_state_key"
+    server.state.setdefault(state_key, 3)
+
+    on_call = MagicMock()
+    server.state.change(state_key)(on_call)
+    with server.state.suppress_change_listeners(state_key):
+        server.state[state_key] = 42
+        server.state.flush()
+
+    await server.network_completion
     await asyncio.sleep(0.1)
-    await client.diconnect()
-    await asyncio.sleep(0.5)
-    await server.stop()
+
+    assert client.state[state_key] == 42
+    on_call.assert_not_called()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,6 @@
 import asyncio
 import weakref
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,12 +20,32 @@ class FakeServer:
     def add_event(self, content, type="msg"):
         self._events.append({"type": type, "content": content})
 
+    @property
+    def pushed_state(self) -> dict:
+        pushed = {}
+        for e in self._events:
+            if e["type"] == "push":
+                pushed.update(e["content"])
+        return pushed
+
     def __repr__(self) -> str:
         lines = [""]
         for line_nb, entry in enumerate(self._events):
             lines.append(f"{line_nb:6} {entry.get('type'):5}: {entry.get('content')}")
         lines.append("")
         return "\n".join(lines)
+
+
+@pytest.fixture
+def server():
+    return FakeServer()
+
+
+@pytest.fixture
+def state(server):
+    _state = State(commit_fn=server._push_state)
+    _state.ready()
+    return _state
 
 
 def test_minimum_change_detection():
@@ -375,3 +396,243 @@ def test_weakref():
     state.a = 3
     state.flush()
     assert Obj.method_call_count == 1
+
+
+def test_given_explicit_keys_when_modified_inside_context_then_listeners_are_not_called(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners("a"):
+        state.a = 2
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+
+
+def test_given_explicit_keys_when_flushing_inside_context_then_listeners_are_not_called(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners("a"):
+        for i in range(3):
+            state.a = i
+            state.flush()
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+
+
+def test_given_no_keys_when_any_key_modified_inside_context_then_listeners_are_not_called(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a", "b")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners():
+        state.a = 2
+        state.b = 3
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+    assert server.pushed_state["b"] == 3
+
+
+def test_given_nested_no_keys_when_any_key_modified_inside_context_then_listeners_are_not_called(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a", "b")
+    def on_change(**_):
+        mock()
+
+    with (
+        state.suppress_change_listeners("d"),
+        state.suppress_change_listeners(),
+        state.suppress_change_listeners("e"),
+    ):
+        state.a = 2
+        state.b = 3
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+    assert server.pushed_state["b"] == 3
+
+
+def test_given_modified_keys_when_context_exits_then_keys_are_marked_clean_in_state(
+    state,
+):
+    with state.suppress_change_listeners("a"):
+        state.a = 2
+
+    state.flush()
+    assert not state.is_dirty("a")
+
+
+def test_given_multiple_nested_suppress_contexts_when_exiting_then_all_keys_are_synced_correctly(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a", "b")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners("a"):
+        state.a = 2
+        state.flush()
+
+        with state.suppress_change_listeners("b"):
+            state.b = 3
+            state.flush()
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+    assert server.pushed_state["b"] == 3
+
+
+def test_given_nested_suppress_with_same_key_keeps_suppression_in_outer_context(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners("a"):
+        with state.suppress_change_listeners("a"):
+            state.a = 3
+            state.flush()
+
+        state.a = 2
+        state.flush()
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["a"] == 2
+
+
+def test_given_mixed_updates_when_some_are_suppressed_then_only_normal_updates_trigger_listeners(
+    state,
+):
+    mock_a = MagicMock()
+    mock_b = MagicMock()
+
+    @state.change("a")
+    def on_a(**_):
+        mock_a()
+
+    @state.change("b")
+    def on_b(b, **_):
+        mock_b(b)
+
+    with state.suppress_change_listeners("a"):
+        state.a = 2
+        state.b = 3
+
+    state.flush()
+    mock_a.assert_not_called()
+    mock_b.assert_called_once_with(3)
+
+
+def test_given_exception_in_context_when_raised_then_cleanup_logic_still_executes(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(a, **_):
+        mock(a)
+
+    try:
+        with state.suppress_change_listeners("a"):
+            raise ValueError()
+    except ValueError:
+        pass
+
+    state.a = 2
+    state.flush()
+    assert server.pushed_state["a"] == 2
+    mock.assert_called_once_with(2)
+
+
+def test_given_namespaced_state_when_using_suppress_context_then_keys_are_correctly_translated(
+    server,
+):
+    translator = Translator(prefix="test_")
+    state = State(translator=translator, commit_fn=server._push_state)
+    state.ready()
+
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(**_):
+        mock()
+
+    with state.suppress_change_listeners("a"):
+        state.a = 2
+
+    state.flush()
+    mock.assert_not_called()
+    assert server.pushed_state["test_a"] == 2
+
+
+def test_given_change_callback_when_it_modifies_state_suppressed_then_recursion_is_avoided(
+    state, server
+):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_a(a, **_):
+        with state.suppress_change_listeners("b"):
+            state.b = a
+            state.flush()
+
+    @state.change("b")
+    def on_b(**_):
+        mock()
+
+    state.a = 2
+    state.flush()
+
+    assert not state.is_dirty("b")
+    assert server.pushed_state["b"] == 2
+    mock.assert_not_called()
+
+
+def test_given_chain_supress_sequence_correctly_suppress_scoped_listeners(state):
+    mock = MagicMock()
+
+    @state.change("a", "b", "c")
+    def on_a(**kwargs):
+        mock(**kwargs)
+
+    with state.suppress_change_listeners():
+        state.a = 1
+        state.b = 2
+
+    with state.suppress_change_listeners("c"):
+        state.a = 42
+        state.c = 3
+
+    state.flush()
+    mock.assert_called_once_with(a=42, b=2, c=3)

--- a/tests/test_typed_state.py
+++ b/tests/test_typed_state.py
@@ -545,3 +545,16 @@ def test_encode_decode_supports_collections_of_nested_dataclass(state):
             }
         },
     }
+
+
+def test_can_supress_change_listeners(state):
+    mock = MagicMock()
+
+    typed_state = TypedState(state, MyBiggerData)
+    typed_state.bind_changes({typed_state.name.my_other_data: mock})
+
+    with typed_state.suppress_change_listeners():
+        typed_state.data.my_other_data.a = 53
+
+    state.flush()
+    mock.assert_not_called()


### PR DESCRIPTION
Adds a context manager to suppress change listener callbacks on the server in its scope. Allows to avoid unwanted backend callbacks when only a client state update is wanted.