### PR TITLE
fix(state): fix dirty not triggering change listeners

### DIFF
--- a/src/trame_server/state.py
+++ b/src/trame_server/state.py
@@ -298,6 +298,7 @@ class State:
         _args = self._translator.translate_list(_args)
         for key in _args:
             self._pending_update.setdefault(key, self._pushed_state.get(key))
+            self._suppress_change_stack.on_pending_key_added(key)
 
     def clean(self, *_args):
         """
@@ -310,6 +311,7 @@ class State:
         for key in _args:
             if key in self._pending_update:
                 self._pushed_state[key] = self._pending_update.pop(key)
+                self._suppress_change_stack.on_pending_key_removed(key)
 
     def update(self, _dict):
         """Update the current state dict with the provided one"""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -636,3 +636,65 @@ def test_given_chain_supress_sequence_correctly_suppress_scoped_listeners(state)
 
     state.flush()
     mock.assert_called_once_with(a=42, b=2, c=3)
+
+
+def test_keys_marked_dirty_triggers_listener_changes(state):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(a, **_):
+        mock(a)
+
+    state.a = 1
+    state.flush()
+    mock.reset_mock()
+
+    state.dirty("a")
+    state.flush()
+    mock.assert_called_once_with(1)
+
+
+def test_keys_marked_dirty_in_suppress_does_not_trigger_listener_changes(state):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(a, **_):
+        mock(a)
+
+    state.a = 1
+    state.flush()
+    mock.reset_mock()
+
+    with state.suppress_change_listeners("a"):
+        state.dirty("a")
+
+    state.flush()
+    mock.assert_not_called()
+
+
+def test_keys_marked_clean_does_not_trigger_listener_changes(state):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(a, **_):
+        mock(a)
+
+    state.a = 2
+    state.clean("a")
+    state.flush()
+    mock.assert_not_called()
+
+
+def test_keys_marked_clean_in_suppress_does_not_trigger_listener_changes(state):
+    mock = MagicMock()
+
+    @state.change("a")
+    def on_change(a, **_):
+        mock(a)
+
+    state.a = 2
+    with state.suppress_change_listeners("a"):
+        state.clean("a")
+
+    state.flush()
+    mock.assert_not_called()


### PR DESCRIPTION
Fix regression introduced by ec70d23a by properly tracking keys marked dirty and clean in the suppress change stack.

Related to #80