### PR TITLE
ci(tests): modernize CI test step

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,11 @@
 [run]
 omit = *docs*, *tests*, setup.py
+source = trame_server
+
+[paths]
+source =
+    src/trame_server
+    */site-packages/trame_server
+
+[report]
+show_missing = True

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -53,13 +53,8 @@ jobs:
 
       - name: Install and Run Tests
         run: |
-          pip install -e ".[dev]"
-          pip install -r tests/requirements.txt
-          # Run the tests with coverage so we get a coverage report too
-          pip install coverage
-          coverage run --omit "*/tests/*" --source ./src -m pytest .
-          # Print the coverage report
-          coverage report -m
+          pip install ".[dev]"
+          pytest --cov
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "ruff",
     "pytest",
     "pytest-asyncio",
+    "pytest-cov",
     "nox",
     "trame",
 ]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,0 @@
-pytest
-pytest-asyncio
-trame
-trame-client


### PR DESCRIPTION
- Remove obsolete tests/requirements files
- Update pyproject.toml dev requirements
- Update coverage.rc file with trame_server path
- Update CI step to rely on pytest --cov directly